### PR TITLE
Clarify search_dir path regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The server implements the following tools:
 
    - Parameters: `query`, optional `subdir`, optional `max_results` (default: 25), optional `context` (default: 5)
 
-5. **search_dir** - Search for files and directories by name using regex
+5. **search_dir** - Search for files and directories using a regex matched against the full path
 
    - Parameters: `regex`, optional `subdir`, optional `max_results` (default: 50)
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -169,13 +169,13 @@ export function registerTools(server: McpServer) {
 	);
 
 	// Search directory tool
-	server.tool(
-		"search_dir",
-		"Search for files and directories by name using regular expressions",
-		{
-			regex: z
-				.string()
-				.describe("Regular expression pattern to match file/directory names"),
+        server.tool(
+                "search_dir",
+                "Search for files and directories using a regular expression applied to the full path",
+                {
+                        regex: z
+                                .string()
+                                .describe("Regular expression pattern to match file/directory paths"),
 			subdir: z
 				.string()
 				.optional()

--- a/src/tools/searchDir.ts
+++ b/src/tools/searchDir.ts
@@ -12,8 +12,11 @@ interface DirSearchResult {
 }
 
 /**
- * Search for files and directories by name using regex
- * @param regex Regular expression pattern to match file/directory names
+ * Search for files and directories using a regex applied to the full path.
+ * The regular expression is matched against the entire path, not just the
+ * basename of the file or directory.
+ *
+ * @param regex Regular expression pattern to match file/directory paths
  * @param subdir Optional subdirectory to limit search scope
  * @param maxResults Maximum number of results to return (default: 50)
  * @returns Array of matching files and directories


### PR DESCRIPTION
## Summary
- document that `search_dir` matches regex on the whole path
- update `search_dir` tool metadata accordingly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68405c6c3608832ba2fec6844523f013